### PR TITLE
gofile-download: allow for retries when connection timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,21 @@ Use the environment variable **`GF_MAX_CONCURRENT_DOWNLOADS`** to configure the 
 | :---: | :---: |
 | **Windows Powershell** | `set GF_MAX_CONCURRENT_DOWNLOADS="5" && python gofile-downloader.py <url>` |
 | **Unix Shell**         | `GF_MAX_CONCURRENT_DOWNLOADS="5" python gofile-downloader.py <url>` |
+
+</br>
+
+Use the environment variable **`GF_MAX_RETRIES`** to configure the number of retries on timeout:
+
+| Platform | Command |
+| :---: | :---: |
+| **Windows Powershell** | `set GF_MAX_RETRIES="5" && python gofile-downloader.py <url>` |
+| **Unix Shell**         | `GF_MAX_RETRIES="5" python gofile-downloader.py <url>` |
+
+</br>
+
+Use the environment variable **`GF_TIMEOUT`** to configure a timeout for connections:
+
+| Platform | Command |
+| :---: | :---: |
+| **Windows Powershell** | `set GF_TIMEOUT="15.0" && python gofile-downloader.py <url>` |
+| **Unix Shell**         | `GF_TIMEOUT="15.0" python gofile-downloader.py <url>` |


### PR DESCRIPTION
- Allow to retry timed out responses with `GF_MAX_RETRIES`, defaults to 5 retries.
- Allow for tunable timeout with `GF_TIMEOUT`, defaults to 15.0 seconds to connect and read.