### PR TITLE
fix: make GoFile like us again

### DIFF
--- a/gofile-downloader.py
+++ b/gofile-downloader.py
@@ -84,7 +84,7 @@ def generate_website_token(user_agent: str, account_token: str) -> str:
     Generates the dynamic X-Website-Token required by GoFile API.
     """
     time_slot = int(time()) // 14400
-    raw = f"{user_agent}::en-US::{account_token}::{time_slot}::9844d94d963d30"
+    raw = f"{user_agent}::en-US::{account_token}::{time_slot}::12af056dacea0b"
     return sha256(raw.encode()).hexdigest()
 
 

--- a/gofile-downloader.py
+++ b/gofile-downloader.py
@@ -84,7 +84,7 @@ def generate_website_token(user_agent: str, account_token: str) -> str:
     Generates the dynamic X-Website-Token required by GoFile API.
     """
     time_slot = int(time()) // 14400
-    raw = f"{user_agent}::en-US::{account_token}::{time_slot}::9844d94d963d30"
+    raw = f"{user_agent}::en-US::{account_token}::{time_slot}::12af056dacea0b"
     return sha256(raw.encode()).hexdigest()
 
 
@@ -754,7 +754,7 @@ class Manager:
 
         self._session.headers.update({
             "Accept-Encoding": "gzip",
-            "User-Agent": self._user_agent if self._user_agent else "Mozilla/5.0",
+            "User-Agent": self._user_agent if self._user_agent else "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36",
             "Connection": "keep-alive",
             "Accept": "*/*",
             "Origin": "https://gofile.io",


### PR DESCRIPTION
GoFile changed the website-token salt again.
Updated the salt and default User-Agent so the downloader can get back in.